### PR TITLE
remove hardware dependencies

### DIFF
--- a/haste-server.init
+++ b/haste-server.init
@@ -52,7 +52,7 @@ stop() {
 }
 
 status() {
-  status_of_proc -p /var/run/$NAME.pid "" "etherpad-lite" && exit 0 || exit $?
+  status_of_proc -p /var/run/$NAME.pid "" "haste-server" && exit 0 || exit $?
 }
 
 case "$1" in

--- a/serviette.sh
+++ b/serviette.sh
@@ -26,11 +26,6 @@ EOF
     
     locale-gen
     
-    # Set up Debian's sources.list
-    cat > /etc/apt/sources.list <<EOL
-deb http://ftp.debian.org/debian jessie main non-free
-deb https://repositories.collabora.co.uk/debian/ jessie rpi2
-EOL
     
     # Install latest system updates
     aptitude update && aptitude -y upgrade

--- a/serviette.sh
+++ b/serviette.sh
@@ -39,7 +39,7 @@ EOF
     dpkg-reconfigure -f noninteractive tzdata
     
     # Install basic tools
-    aptitude -y install zsh vim less gzip git-core curl python g++ iw wpasupplicant wireless-tools bridge-utils screen tmux mosh ed strace cowsay figlet toilet at pv mmv iputils-tracepath tre-agrep urlscan urlview autossh elinks irssi-scripts ncftp sc byobu mc tree atop iftop iotop nmap antiword moreutils net-tools whois pwgen haveged usbutils w3m htop nethack
+    aptitude -y install zsh vim less gzip git-core curl python g++ iw wpasupplicant wireless-tools bridge-utils screen tmux mosh ed strace cowsay figlet toilet at pv mmv iputils-tracepath tre-agrep urlscan urlview autossh elinks irssi-scripts ncftp sc byobu mc tree atop iftop iotop nmap antiword moreutils net-tools whois pwgen haveged usbutils w3m htop nethack-console
 }
 
 #################################################
@@ -47,8 +47,8 @@ EOF
 #################################################
 
 function configure_network {
-    # Firmware for rt2800usb (USB WiFi) 
-    aptitude install firmware-ralink
+    # The correct firmware should be installed and a wlan0 interface present as
+    # a minimal requirement
 
     cat > /etc/network/interfaces <<EOF
 # interfaces(5) file used by ifup(8) and ifdown (8)                                                                                                                                  
@@ -57,6 +57,7 @@ iface lo inet loopback
 
 # LAN - Wired
 auto eth0
+iface eth0 inet dhcp
 
 # LAN - Wifi
 auto wlan1
@@ -101,6 +102,9 @@ iptables -A FORWARD -p TCP --dport 11371 -j REJECT
 exit 0
 EOF
 }
+
+# Run the rc.local to put firewall rules in place
+/etc/rc.local
 
 #################################################
 # Wireless Access Point
@@ -180,7 +184,7 @@ EOF
     # Create public default host
     cat > /etc/nginx/sites-available/serviette.lan <<EOF
 server {
-        server_name serviette.lan
+        server_name serviette.lan;
 
         root /var/www;
         index index.html index.htm;
@@ -529,7 +533,7 @@ EOF
 
 function install_sipwitch {
     # Install Sipwitch
-    aptitude -y install Sipwitch
+    aptitude -y install sipwitch
 
     # Automatically load available plugins
     sed -i 's/#PLUGINS=.*/PLUGINS="auto"/' /etc/default/sipwitch

--- a/sharingiscaring.init
+++ b/sharingiscaring.init
@@ -52,7 +52,7 @@ stop() {
 }
 
 status() {
-  status_of_proc -p /var/run/$NAME.pid "" "etherpad-lite" && exit 0 || exit $?
+  status_of_proc -p /var/run/$NAME.pid "" "sharingiscaring" && exit 0 || exit $?
 }
 
 case "$1" in


### PR DESCRIPTION
During the Knoppixtage 2015 in Weiz a Banana Pro has been used as a serviette. The install script has been modified to further reduce the hardware dependent parts and some minor typos in package names and config files corrected.
