### PR TITLE
Vagrantify

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require "fileutils"
+
+# the following is adapted from https://gist.github.com/juanje/3797297
+def local_cache(basebox_name)
+	cache_dir = Vagrant::Environment.new.home_path.join('cache', 'apt', basebox_name)
+	partial_dir = cache_dir.join('partial')
+	FileUtils.makedirs(partial_dir) unless partial_dir.exist?
+	cache_dir
+end
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "debian/jessie64"
+  config.vm.network "private_network", type: "dhcp"
+  config.vm.synced_folder "../serviette", "/serviette"
+  cache_dir = local_cache(config.vm.box)
+  config.vm.synced_folder cache_dir, "/var/cache/apt/archives/"
+
+  # workaround for "not a stdin"
+  # https://github.com/mitchellh/vagrant/issues/1673
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+
+  # do the serviette install in the provisioning phase
+  config.vm.provision :shell, inline: "/bin/bash /serviette/serviette.sh"
+end

--- a/serviette.sh
+++ b/serviette.sh
@@ -26,11 +26,6 @@ EOF
     
     locale-gen
     
-    # Set up Debian's sources.list
-    cat > /etc/apt/sources.list <<EOL
-deb http://ftp.debian.org/debian jessie main non-free
-deb https://repositories.collabora.co.uk/debian/ jessie rpi2
-EOL
     
     # Install latest system updates
     aptitude update && aptitude -y upgrade

--- a/serviette.sh
+++ b/serviette.sh
@@ -39,7 +39,7 @@ EOF
     dpkg-reconfigure -f noninteractive tzdata
     
     # Install basic tools
-    aptitude -y install zsh vim less gzip git-core curl python g++ iw wpasupplicant wireless-tools bridge-utils screen tmux mosh ed strace cowsay figlet toilet at pv mmv iputils-tracepath tre-agrep urlscan urlview autossh elinks irssi-scripts ncftp sc byobu mc tree atop iftop iotop nmap antiword moreutils net-tools whois pwgen haveged usbutils w3m htop nethack
+    aptitude -y install zsh vim less gzip git-core curl python g++ iw wpasupplicant wireless-tools bridge-utils screen tmux mosh ed strace cowsay figlet toilet at pv mmv iputils-tracepath tre-agrep urlscan urlview autossh elinks irssi-scripts ncftp sc byobu mc tree atop iftop iotop nmap antiword moreutils net-tools whois pwgen haveged usbutils w3m htop nethack-console
 }
 
 #################################################
@@ -47,8 +47,8 @@ EOF
 #################################################
 
 function configure_network {
-    # Firmware for rt2800usb (USB WiFi) 
-    aptitude install firmware-ralink
+    # The correct firmware should be installed and a wlan0 interface present as
+    # a minimal requirement
 
     cat > /etc/network/interfaces <<EOF
 # interfaces(5) file used by ifup(8) and ifdown (8)                                                                                                                                  
@@ -57,6 +57,7 @@ iface lo inet loopback
 
 # LAN - Wired
 auto eth0
+iface eth0 inet dhcp
 
 # LAN - Wifi
 auto wlan1
@@ -101,6 +102,9 @@ iptables -A FORWARD -p TCP --dport 11371 -j REJECT
 exit 0
 EOF
 }
+
+# Run the rc.local to put firewall rules in place
+/etc/rc.local
 
 #################################################
 # Wireless Access Point
@@ -180,7 +184,7 @@ EOF
     # Create public default host
     cat > /etc/nginx/sites-available/serviette.lan <<EOF
 server {
-        server_name serviette.lan
+        server_name serviette.lan;
 
         root /var/www;
         index index.html index.htm;
@@ -529,7 +533,7 @@ EOF
 
 function install_sipwitch {
     # Install Sipwitch
-    aptitude -y install Sipwitch
+    aptitude -y install sipwitch
 
     # Automatically load available plugins
     sed -i 's/#PLUGINS=.*/PLUGINS="auto"/' /etc/default/sipwitch


### PR DESCRIPTION
Recreating a fresh serviette on "real hardware" is a rather time consuming process (write the OS to the SD-card, plug it into the board, hook the board to a monitor/keyboard/etc., boot it, clone the repository, run the installer, ...).
This made me put off further activity so I did what one does in such cases: automate the process.

The Vagrantfile will spin up a debian/jessie64 box and automatically run the serviette.sh. After the first `vagrant up`, after the off-VM apt package cache has been filled, this process is acceptably fast:

```
$ time vagrant up
[...]
real    6m53.675s
user    0m11.632s
sys 0m3.796s
```

Once the box is up and running, one can start using the serviette services (from the host only due to the `private_network` configuration). To get the IP address run `vagrant ssh` to connect to the box and then `ip -4 addr show dev eth1` from within the VM for the address.
